### PR TITLE
Add semi to fuzzy match denylist

### DIFF
--- a/jumpbot.py
+++ b/jumpbot.py
@@ -15,7 +15,7 @@ from math import copysign
 graph_save_path = './data/graph.cache'
 
 # systems we don't want fuzzy matching to hit on in fleetping triggers
-fuzzy_match_denylist = ['gate', 'serpentis']
+fuzzy_match_denylist = ['gate', 'serpentis', 'semi']
 
 # when fuzzy matching chats to system names, ignore these chars
 punctuation_to_strip = '[.,;:!\'"]'


### PR DESCRIPTION
"Come join me as we semi afk rat the level 6's in our pocket, currently in 2G38-I. I will handle loot" triggered the bot to display routes for the Semiki. Hopefully this is the correct way of preventing it doing so in the future.